### PR TITLE
manage group privileges

### DIFF
--- a/library.js
+++ b/library.js
@@ -233,8 +233,8 @@ exports.load = function ({ app, middleware, router }, next) {
 
     if (!data) return callback(new Error('[[error:invalid-data]]'))
 
-    // Modmins can modify groups privileges :)
-    // if (!(parseInt(data.member, 10) && parseInt(data.member, 10)+'' === data.member+'')) return callback(new Error('[[error:not-authorized]]'))
+    // Modmins can modify groups privileges, unless the setting is changes :)
+    if (!(parseInt(data.member, 10) && parseInt(data.member, 10)+'' === data.member+'') && !settings.get('manage-groups')) return callback(new Error('[[error:not-authorized]]'))
 
     // Modmins can't set global privileges.
     if (!cid) return callback(new Error('[[error:not-authorized]]'))

--- a/library.js
+++ b/library.js
@@ -287,7 +287,7 @@ exports.load = function ({ app, middleware, router }, next) {
     const {uid} = socket
     const {cid} = data
 
-    return callback(new Error('[[error:not-authorized]]'))
+    if (!settings.get('manage-groups')) return callback(new Error('[[error:not-authorized]]'))
 
     async.waterfall([
       function (next) {
@@ -328,7 +328,7 @@ exports.load = function ({ app, middleware, router }, next) {
     const uid = socket.uid
 
     // Don't manage group privileges.
-    return callback(new Error('[[error:not-authorized]]'))
+    if (settings.get('manage-groups')) return callback(new Error('[[error:not-authorized]]'))
 
     async.every([fromCid, toCid], (cid, next) => isAdminOrModmin(cid, uid, next), (err, isAdminOrModmin) => {
       if (err || !isAdminOrModmin) return callback(new Error('[[error:not-authorized]]'))

--- a/public/language/de/modmin.json
+++ b/public/language/de/modmin.json
@@ -1,14 +1,11 @@
 {
   "title": "Kategorie verwalten",
-  "intro": "You can configure the privileges and settings for categories on this page. Privileges can be granted on a per-user or a per-group basis. Select the category from the dropdown below.",
   "intro": "Auf dieser Seite kannst du Privilegien und Einstellung für Kategorien verwalten. Privilegien können für einzelne Nutzer oder für Gruppen erteilt werden. Wähle die Kategorie aus der Dropdown-Liste.",
   "edit_category": "Kategorie bearbeiten",
   "new_subcategory": "Unterkategorie erstellen",
   "category_icon": "Kategorie Icon",
-  "assign_group": "Assign Group <small>Will make the category only accessable by this group.</small>",
   "assign_group": "Gruppe zuweisen <small>Dadurch wird der Zugang der Kategorie auf Gruppenmitglieder beschränkt.</small>",
   "show_badge": "Abzeiche anzeigen <small>Abzeichen Einstellung für zugewiesene Gruppe.</small>",
-  "assign_owner": "Assign Owner <small>If a user is selected, they will become a manager of the category and group.</small>",
   "assign_owner": "Gruppenadmin zuweisen <small>Der ausgewählte Nutzer kann die Kategorie und Gruppe verwalten.</small>",
   "category_edited": "Kategorie erfolgreich bearbeitet",
   "subcategory_added": "Unterkategorie erstellt",
@@ -19,6 +16,7 @@
   "group_exists": "Gruppe existiert bereits",
   "config_title": "Modmin Settings",
   "config_intro": "Select which privileges Category Managers can edit.",
+  "config_groups": "Gruppen Privilegien verwalten",
   "become_group_owner": "Become Group Owner",
   "group_owned": "You are now the group owner!"
 }

--- a/public/language/en-US/modmin.json
+++ b/public/language/en-US/modmin.json
@@ -16,6 +16,7 @@
   "group_exists": "Group already exists.",
   "config_title": "Modmin Settings",
   "config_intro": "Select which privileges Category Managers can edit.",
+  "config_groups": "Manage Group Privileges",
   "become_group_owner": "Become Group Owner",
   "group_owned": "You are now the group owner!"
 }

--- a/public/language/pl/modmin.json
+++ b/public/language/pl/modmin.json
@@ -1,0 +1,22 @@
+{
+  "title": "Zarządzaj Kategorią",
+  "intro": "Na tej stronie możesz konfigurować uprawnienia i ustawienia kategorii. Uprawnienia mogą być przyznawane dla użytkowników lub grup. Wybierz kategorię z menu poniżej.",
+  "edit_category": "Edytuj Kategorię",
+  "new_subcategory": "Stwórz Podkategorię",
+  "category_icon": "Obrazek Kategorii",
+  "assign_group": "Przypisz grupę <small>Sprawi, że kategoria będzie dostępna tylko dla tej grupy</small>",
+  "show_badge": "Pokaż Etykietę <small>Ustawienia etykiet przypisanych do grupy.</small>",
+  "assign_owner": "Przypisz Właściciela <small>Wybrany użytkownik będzie mógł zarządzać kategorią i grupą.</small>",
+  "category_edited": "Kategoria Zmienione!",
+  "subcategory_added": "Podkategoria Dodana!",
+  "group_created": "Grupa Stworzona!",
+  "error_data": "Błąd przy odzyskiwaniu danych kategorii.",
+  "privileges_copied": "Uprawnienia skopiowane!",
+  "invalid_owner": "Niewłaściwy Właściciel",
+  "group_exists": "Grupa już istnieje.",
+  "config_title": "Ustawienia Modmin",
+  "config_intro": "Wybierz jakie uprawnienia Właściciele Kategorii mogą edytować.",
+  "config_groups": "Zarządzanie uprawnieniami grup",
+  "become_group_owner": "Stań się Właścicielem Grupy",
+  "group_owned": "Jesteś Właścicielem Grupy!"
+}

--- a/public/less/style.less
+++ b/public/less/style.less
@@ -17,7 +17,7 @@
     }
   }
 
-  .privilege-table:nth-child(2), .privilege-table-header, .help-block {
+  .privilege-table-header, .help-block {
     display: none;
   }
 }

--- a/public/templates/modmin/category.tpl
+++ b/public/templates/modmin/category.tpl
@@ -40,3 +40,10 @@
 		</div>
 	</form>
 </div>
+<!-- IF canManageGroups -->
+<style>
+.privilege-table:nth-child(2){
+	display: none;
+}
+</style>
+<!-- ENDIF canManageGroups -->

--- a/public/templates/modmin/config.tpl
+++ b/public/templates/modmin/config.tpl
@@ -23,9 +23,9 @@
 								</th>
 							</tr><tr><!-- zebrastripe reset --></tr>
 							<tr>
-								<!-- BEGIN userPrivilegesLabels -->
-								<th class="text-center">{userPrivilegesLabels.name}</th>
-								<!-- END userPrivilegesLabels -->
+								<!-- BEGIN PrivilegesLabels -->
+								<th class="text-center">{PrivilegesLabels.name}</th>
+								<!-- END PrivilegesLabels -->
 							</tr>
 						</thead>
 						<tbody>
@@ -37,7 +37,38 @@
                 <!-- END userPrivileges -->
 							</tr>
 						</tbody>
-        </table>
+				</table>
+				<h1><input type="checkbox" data-key="manage-groups"> [[modmin:config_groups]]</h1>
+				<table class="table table-striped privilege-table">
+						<thead>
+							<tr class="privilege-table-header">
+								<th colspan="2"></th>
+								<th class="arrowed" colspan="3">
+									[[admin/manage/categories:privileges.section-viewing]]
+								</th>
+								<th class="arrowed" colspan="9">
+									[[admin/manage/categories:privileges.section-posting]]
+								</th>
+								<th class="arrowed" colspan="3">
+									[[admin/manage/categories:privileges.section-moderation]]
+								</th>
+							</tr><tr><!-- zebrastripe reset --></tr>
+							<tr>
+								<!-- BEGIN PrivilegesLabels -->
+								<th class="text-center">{PrivilegesLabels.name}</th>
+								<!-- END PrivilegesLabels -->
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+                <!-- BEGIN groupPrivileges -->
+								<td>
+									<input type="checkbox" data-key="@value">
+								</td>
+                <!-- END groupPrivileges -->
+							</tr>
+						</tbody>
+        	</table>
 			</div>
 		</div>
 	</form>


### PR DESCRIPTION
As the title suggests: adds the ability to modify group privileges from modmin interface.

This can be toggled in ACP (a checkbox in ACP enables or disables this - when disabled the plugin behaves exactly like before this change) and admin panel was also expanded so now you can decide what permissions can be managed by modmins separately for groups and individual users.

Implements first part of feature request #4 

Oh, and there is also a polish translation in here... No reason not to add it here if I already made it earlier :)