### PR TITLE
Make the plugin compatible with 1.13.x

### DIFF
--- a/library.js
+++ b/library.js
@@ -97,7 +97,8 @@ exports.load = function ({ app, middleware, router }, next) {
                   },
                   function (categoriesData, next) {
                     categoriesData = Categories.getTree(categoriesData)
-                    Categories.buildForSelectCategories(categoriesData, next)
+                    categoriesData = Categories.buildForSelectCategories(categoriesData)
+                    next(null, categoriesData)
                   },
                 ], next)
               },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-modmin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "yariplus",
     "email": "tafike@gmail.com"
@@ -17,6 +17,6 @@
     "admin"
   ],
   "nbbpm": {
-    "compatibility": "^1.0.0"
+    "compatibility": "^1.13.0"
   }
 }


### PR DESCRIPTION
Categories.buildForSelectCategories changed in 1.13.x and the plugin no longer works on the newest version - and it crashes the whole NodeBB when trying to load the modmin page. Fixed it, but it probably breaks the compatibility with earlier version, so I also updated `package.json` to make it compatible only with versions from 1.13.0 (I also upped the plugin version to 1.3.2 w while was at it)